### PR TITLE
flip comparison

### DIFF
--- a/R/open-dsn-channel.R
+++ b/R/open-dsn-channel.R
@@ -49,7 +49,7 @@ open_dsn_channel_sqls <- function(
   create_link <- "https://github.com/OuhscBbmc/BbmcResources/blob/master/instructions/odbc-dsn.md"
   driver_link <- "https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server"
   
-  dsn_exists <- (dsn_name %in% RODBC::odbcDataSources())
+  dsn_exists <- (dsn_name %in% names(RODBC::odbcDataSources()))
   if( !dsn_exists ) {
     m <- "The DSN `%s` does not exist on your local machine.  Please see the installation instructions at %s."
     stop(sprintf(m, dsn_name, create_link))    
@@ -65,15 +65,16 @@ open_dsn_channel_sqls <- function(
 
   info <- RODBC::odbcGetInfo(channel)
 
+  # print(numeric_version(info["Driver_Ver"]))
   
-  if( driver_version_minimum <= numeric_version(info["Driver_Ver"]) ) {
+  if( !(driver_version_minimum <= numeric_version(info["Driver_Ver"])) ) {
     RODBC::odbcClose(channel)
-    m <- "The SQL Server ODBC driver version must be at least %s.  Please download the newest version at %.  Please see the installation instructions at %s."
-    stop(sprintf(m, driver_version_minimum, driver_link, create_link))
-  } else if ( numeric_version(info["Driver_Ver"]) <= driver_version_minimum) {
+    m <- "The SQL Server ODBC driver version must be at least %s.  Please download the newest version at %s.  Please see the installation instructions at %s."
+    stop(sprintf(m, as.character(driver_version_minimum), driver_link, create_link))
+  } else if (!(numeric_version(info["Driver_Ver"]) <= driver_version_maximum)) {
     RODBC::odbcClose(channel)
-    m <- "The SQL Server ODBC driver version must be not exceed %s.  Please download an earlier version at %.  Please see the installation instructions at %s."
-    stop(sprintf(m, driver_version_maximum, driver_link, create_link))
+    m <- "The SQL Server ODBC driver version must be not exceed %s.  Please download an earlier version at %s.  Please see the installation instructions at %s."
+    stop(sprintf(m, as.character(driver_version_maximum), driver_link, create_link))
   }
 
   return( channel )


### PR DESCRIPTION
was the opposite direction from the previous `testit::assert()` call.
There were two other dumb/untested mistakes.

See #24